### PR TITLE
Add Views and Controllers for Layouts

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,3 @@
+class StaticController < ApplicationController
+  def home; end
+end

--- a/app/controllers/store_admin_controller.rb
+++ b/app/controllers/store_admin_controller.rb
@@ -1,0 +1,12 @@
+class StoreAdminController < ApplicationController
+  layout 'admin'
+  def home; end
+
+  def orders
+    render layout: 'order_administration'
+  end
+
+  def invoice
+    render layout: false
+  end
+end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,2 @@
+<h1>Flatiron Widgets: Admin</h1>
+<%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,2 @@
+<h1>Flatiron Widgets Store</h1>
+<%= yield %>

--- a/app/views/layouts/order_administration.html.erb
+++ b/app/views/layouts/order_administration.html.erb
@@ -1,0 +1,2 @@
+<h1>Flatiron Widgets: Open Orders</h1>
+<%= yield %>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -1,0 +1,1 @@
+<h2>Welcome to Flatiron Widgets</h2>

--- a/app/views/store_admin/home.html.erb
+++ b/app/views/store_admin/home.html.erb
@@ -1,0 +1,1 @@
+<h2>Welcome Flatiron Admin</h2>

--- a/app/views/store_admin/invoice.html.erb
+++ b/app/views/store_admin/invoice.html.erb
@@ -1,0 +1,1 @@
+<h1>Your Invoice</h1>

--- a/app/views/store_admin/orders.html.erb
+++ b/app/views/store_admin/orders.html.erb
@@ -1,0 +1,6 @@
+<h2>Welcome to Flatiron Open Orders</h2>
+<ol>
+  <li>A</li>
+  <li>B</li>
+  <li>C</li>
+</ol>


### PR DESCRIPTION
This pull request introduces new controllers and views to support both the public-facing and admin sections of the Flatiron Widgets store. It sets up separate layouts for the main application, admin dashboard, and order administration, and adds basic home, orders, and invoice pages for both users and admins.

**Controllers:**

- Added `StaticController` with a `home` action for the main store landing page.
- Added `StoreAdminController` with `home`, `orders`, and `invoice` actions, each using specific layouts for admin and order pages.

**Layouts:**

- Created `admin.html.erb` layout for admin pages.
- Created `order_administration.html.erb` layout for order management pages.
- Updated `application.html.erb` layout for the main store.

**Views:**

- Added home page views for both the store (`static/home.html.erb`) and admin (`store_admin/home.html.erb`). [[1]](diffhunk://#diff-43e65f685d16fc514d8d8a13d8aedaef8614c5666642e2c9550e3931cc8c066dR1) [[2]](diffhunk://#diff-21295045c15e2345f6cbdc69b2555e8b40364c40af93246f2b364bd09c0bdc9aR1)
- Added `orders.html.erb` for displaying open orders in the admin section.
- Added `invoice.html.erb` for displaying invoices without a layout.